### PR TITLE
fix(levelling): avoid unboundlocalerror for printers without qgl etc.

### DIFF
--- a/probe_accuracy_test_suite.py
+++ b/probe_accuracy_test_suite.py
@@ -283,6 +283,7 @@ def level_bed(force=False) -> None:
             "User has no leveling gcode. Please check printer.cfg [z_tilt] or [quad_gantry_level]"
         )
         print("Skip leveling...")
+        return
 
     if (not leveled) or force:
         print("Leveling")
@@ -427,7 +428,7 @@ def fetch_repo():
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser(
-        description="""Automated probe testing. 
+        description="""Automated probe testing.
     All three tests will run at default values unless individual tests are specified"""
     )
     ap.add_argument(


### PR DESCRIPTION
I came across the following error when running the probe test on a V0 which does not have QGL or Z_TILT.

```console
Homing
User has no leveling gcode. Please check printer.cfg [z_tilt] or [quad_gantry_level]
Skip leveling...
Traceback (most recent call last):
  File "/home/pi/probe_accuracy_tests/./probe_accuracy_test_suite.py", line 495, in <module>
    main(args)
  File "/home/pi/probe_accuracy_tests/./probe_accuracy_test_suite.py", line 41, in main
    level_bed()
  File "/home/pi/probe_accuracy_tests/./probe_accuracy_test_suite.py", line 287, in level_bed
    if (not leveled) or force:
UnboundLocalError: local variable 'leveled' referenced before assignment
```

Return before the assignment is tested, as we won't be running levelling in this scenario.
