### PR TITLE
Fixed Klicky detection

### DIFF
--- a/probe_accuracy_test_suite.py
+++ b/probe_accuracy_test_suite.py
@@ -511,7 +511,7 @@ def detect_probe():
     user_variables = query_printer_objects("gcode_macro _User_Variables")
 
     try:
-        if user_variables["dockarmslenght"]:
+        if user_variables["docklocation_x"]:
             global isKlicky
             isKlicky = True
     except:


### PR DESCRIPTION
Changed user variable used to detect klicky as this variable doesn't exist in Klicky config variables. I suggest using docklocation_x as it is required. Thanks to this, safe_z variable is correctly detected by the script and doesn't prompt the user to type a safe z location.