### PR TITLE
Fix Klicky macros detection

### DIFF
--- a/probe_accuracy_test_suite.py
+++ b/probe_accuracy_test_suite.py
@@ -105,8 +105,8 @@ class Probe():
         print("Probe type: ..." )
 
         try:
-            settings = self.printer.query("configfile", "settings")
-            if settings["docklocation_x"]:
+            user_variables = self.printer.query("gcode_macro _User_Variables")
+            if user_variables["docklocation_x"]:
                 self.isKlicky = True
                 print(f"{ CLEAR_LINE }Probe type: Klicky mode detected")
                 returnp

--- a/probe_accuracy_test_suite.py
+++ b/probe_accuracy_test_suite.py
@@ -109,7 +109,7 @@ class Probe():
             if user_variables["docklocation_x"]:
                 self.isKlicky = True
                 print(f"{ CLEAR_LINE }Probe type: Klicky mode detected")
-                returnp
+                return
         except:
             pass
 


### PR DESCRIPTION
Issue : Unable to detect Klicky Macros (older & newer versions) on a Voron 2.4 printer
```pi@myprinter:~/probe_accuracy_tests $ python3 probe_accuracy_test_suite.py -c 10
Probe type: ...
Z_STOP
ERROR: No probe could be found.
```
The changes fix small typo and detection of klicky macros
