### PR TITLE
fix: change output_dir arg from array to str

### DIFF
--- a/probe_accuracy_test_suite.py
+++ b/probe_accuracy_test_suite.py
@@ -897,7 +897,7 @@ if __name__ == "__main__":
     ap.add_argument(
         "-o",
         "--output_dir",
-        nargs = 1,
+        type = str,
         help = "Output folder for testresults",
     )
     ap.add_argument(


### PR DESCRIPTION
An invalid filename is created when using the --output_dir/-o option.

```console
python3 probe_accuracy_test_suite.py -c --export_csv -o $PWD/results/alu_tap01

....... REDACTED RESULTS .......

Traceback (most recent call last):
  File "/home/pi/probe_accuracy_tests/probe_accuracy_test_suite.py", line 925, in <module>
    main(args)
  File "/home/pi/probe_accuracy_tests/probe_accuracy_test_suite.py", line 812, in main
    printer_test_suite.run()
  File "/home/pi/probe_accuracy_tests/probe_accuracy_test_suite.py", line 365, in run
    self.test_corner()
  File "/home/pi/probe_accuracy_tests/probe_accuracy_test_suite.py", line 425, in test_corner
    self._facet_plot(testframe, cols = 2, plot_nm = plot_nm)
  File "/home/pi/probe_accuracy_tests/probe_accuracy_test_suite.py", line 733, in _facet_plot
    fig.savefig(f"{ self.output_dir }/{ file_nm }.png")
  File "/usr/lib/python3/dist-packages/matplotlib/figure.py", line 2311, in savefig
    self.canvas.print_figure(fname, **kwargs)
  File "/usr/lib/python3/dist-packages/matplotlib/backend_bases.py", line 2210, in print_figure
    result = print_method(
  File "/usr/lib/python3/dist-packages/matplotlib/backend_bases.py", line 1639, in wrapper
    return func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_agg.py", line 510, in print_png
    mpl.image.imsave(
  File "/usr/lib/python3/dist-packages/matplotlib/image.py", line 1611, in imsave
    image.save(fname, **pil_kwargs)
  File "/home/pi/.local/lib/python3.9/site-packages/PIL/Image.py", line 2209, in save
    fp = builtins.open(filename, "w+b")
FileNotFoundError: [Errno 2] No such file or directory: "['/home/pi/probe_accuracy_tests/results/alu_tap01']/20240130_2125_corner_test.png"
```

With the fix the script no longer errors and the folder contains 4 files.

[Attribution from SO](https://stackoverflow.com/a/52087323)