### PR TITLE
Allow mesh to start at X0 or Y0

### DIFF
--- a/probe_accuracy_test_suite.py
+++ b/probe_accuracy_test_suite.py
@@ -246,13 +246,13 @@ class Printer:
         echo = False
     ):
         gcode_cmd = "G0"
-        if x:
+        if x != None:
             gcode_cmd += f" X{ x }"
-        if y:
+        if y != None:
             gcode_cmd += f" Y{ y }"
-        if z:
+        if z != None:
             gcode_cmd += f" Z{ z }"
-        if feedrate:
+        if feedrate != None:
             gcode_cmd += f" F{ feedrate }"
 
         if echo:


### PR DESCRIPTION
My bed mesh starts at `xmin = 0`, which led to the X portion of the move to not be executed. 

To reproduce:
```toml
[probe]
x_offset: 25
y_offset: 0

[bed_mesh]
mesh_min: 25,10
mesh_max: 110, 110
```

https://github.com/sporkus/probe_accuracy_tests/blob/master/probe_accuracy_test_suite.py#L323 will resolve to `xmin = 0`, leading to https://github.com/sporkus/probe_accuracy_tests/blob/master/probe_accuracy_test_suite.py#L249 to be evaluated to `False`

Thank you very much for these tools!